### PR TITLE
[DEV-169] Add CLI selectors and use them instead of StructFormatters

### DIFF
--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -2,9 +2,8 @@ package cmd
 
 import (
 	"github.com/rockset/cli/format"
-	"github.com/spf13/cobra"
-
 	"github.com/rockset/rockset-go-client/option"
+	"github.com/spf13/cobra"
 )
 
 func newListAliasesCmd() *cobra.Command {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -26,10 +26,11 @@ const (
 	SizeFlag             = "size"
 	IngestTransformation = "ingest-transformation"
 
-	FormatFlag = "format"
-	WideFlag   = "wide"
-	HeaderFlag = "header"
-	ForceFlag  = "force"
+	FormatFlag   = "format"
+	WideFlag     = "wide"
+	HeaderFlag   = "header"
+	SelectorFlag = "selector"
+	ForceFlag    = "force"
 )
 
 const (

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -8,24 +8,26 @@ import (
 
 func formatOne(cmd *cobra.Command, a any) error {
 	wide, _ := cmd.Flags().GetBool(HeaderFlag)
+	selector, _ := cmd.Flags().GetString(SelectorFlag)
 
 	f, err := formatterFor(cmd)
 	if err != nil {
 		return err
 	}
 
-	return f.Format(wide, a)
+	return f.Format(wide, selector, a)
 }
 
 func formatList(cmd *cobra.Command, a []any) error {
 	wide, _ := cmd.Flags().GetBool(HeaderFlag)
+	selector, _ := cmd.Flags().GetString(SelectorFlag)
 
 	f, err := formatterFor(cmd)
 	if err != nil {
 		return err
 	}
 
-	return f.FormatList(wide, a)
+	return f.FormatList(wide, selector, a)
 }
 
 func formatterFor(cmd *cobra.Command) (format.Formatter, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,7 @@ For more configuration options, see the 'rockset create config' command.`, APIKe
 		strings.Join(format.SupportedFormats.ToStringArray(), ", ")))
 	root.PersistentFlags().Bool(HeaderFlag, true, "show header")
 	root.PersistentFlags().Bool(WideFlag, false, "show extended fields")
+	root.PersistentFlags().String(SelectorFlag, "", fmt.Sprintf(`Allows displaying custom values in tables (ignored if --%s is anything other than "%s" or "%s"). Has the format "Column Name:.Field1.Subfield,Column 2 Name:.Selector" etc. The column name and colon can be ommitted, in which case the column and selector will be identical.`, FormatFlag, format.TableFormat, format.CSVFormat))
 
 	root.PersistentFlags().String(ContextFLag, "", fmt.Sprintf("override currently selected configuration context%s", current))
 	root.PersistentFlags().String(ClusterFLag, "", "override Rockset cluster")

--- a/format/alias.go
+++ b/format/alias.go
@@ -2,36 +2,9 @@ package format
 
 import "github.com/rockset/rockset-go-client/openapi"
 
-var AliasFormatter = StructFormatter{
-	[]Header{
-		{
-			FieldName: "Workspace",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "Name",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "Description",
-			FieldFn:   getFieldByName,
-			Wide:      true,
-		},
-		{
-			DisplayName: "Modified At",
-			FieldName:   "ModifiedAt",
-			FieldFn:     getFieldByName,
-			Wide:        true,
-		},
-		{
-			FieldName: "Collections",
-			FieldFn:   getArrayFieldByName,
-		},
-		{
-			FieldName: "State",
-			FieldFn:   getFieldByName,
-		},
-	},
+var AliasDefaultSelector = DefaultSelector{
+	Normal: "Workspace:.workspace,Name:.name,Collections:.collections,State:.state",
+	Wide:   "Workspace:.workspace,Name:.name,Description:.description,Modified At:.modified_at,Collections:.collections,State:.state",
 }
 
 // just to list available fields

--- a/format/api_key.go
+++ b/format/api_key.go
@@ -2,41 +2,9 @@ package format
 
 import "github.com/rockset/rockset-go-client/openapi"
 
-var APIKeyFormatter = StructFormatter{
-	[]Header{
-		{
-			FieldName: "Name",
-			FieldFn:   getFieldByName,
-		},
-		{
-			DisplayName: "Key ID",
-			FieldName:   "Key",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Created By",
-			FieldName:   "CreatedBy",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Expiry Time",
-			FieldName:   "ExpiryTime",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Last Access Time",
-			FieldName:   "LastAccessTime",
-			FieldFn:     getFieldByName,
-		},
-		{
-			FieldName: "Role",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "State",
-			FieldFn:   getFieldByName,
-		},
-	},
+var ApiKeyDefaultSelector = DefaultSelector{
+	Normal: "Name:.name,Key ID:.key,Created By:.created_by,Expiry Time:.expiry_time,Last Access Time:.last_access_time,Role:.role,State:.state",
+	Wide:   "",
 }
 
 // just to list available fields

--- a/format/collection.go
+++ b/format/collection.go
@@ -1,47 +1,6 @@
 package format
 
-var CollectionFormatter = StructFormatter{
-	[]Header{
-		{
-			FieldName: "Workspace",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "Name",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "Description",
-			FieldFn:   getFieldByName,
-		},
-		{
-			DisplayName: "Retention",
-			FieldName:   "RetentionSecs",
-			FieldFn:     getFieldByName,
-		},
-		{
-			FieldName: "Status",
-			FieldFn:   getFieldByName,
-		},
-		{
-			DisplayName: "Insert Only",
-			FieldName:   "InsertOnly",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Read Only",
-			FieldName:   "ReadOnly",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Created By",
-			FieldName:   "CreatedBy",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Created At",
-			FieldName:   "CreatedAt",
-			FieldFn:     getFieldByName,
-		},
-	},
+var CollectionDefaultSelector = DefaultSelector{
+	Normal: "Workspace:.workspace,Name:.name,Description:.description,Retention:.retention_secs,Status:.status,Insert Only:.insert_only,Read Only:.read_only,Created By:.created_by,Created At:.created_at",
+	Wide:   "",
 }

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -16,6 +16,20 @@ func TestFormatter(t *testing.T) {
 		s string
 	}{
 		{
+			i: openapi.Alias{
+				Collections:         []string{"collection1", "collection2"},
+				CreatedAt:           openapi.PtrString("created at"),
+				CreatedByApikeyName: openapi.PtrString("created by apikey name"),
+				CreatorEmail:        openapi.PtrString("creator email"),
+				Description:         openapi.PtrString("description"),
+				ModifiedAt:          openapi.PtrString("modified at"),
+				Name:                openapi.PtrString("name"),
+				State:               openapi.PtrString("state"),
+				Workspace:           openapi.PtrString("workspace"),
+			},
+			s: "workspace,name,description,modified at,\"collection1, collection2\",state\n",
+		},
+		{
 			i: openapi.Workspace{
 				CreatedAt:       openapi.PtrString("created at"),
 				CreatedBy:       openapi.PtrString("created by"),
@@ -107,7 +121,12 @@ func TestFormatter(t *testing.T) {
 			buf := bytes.NewBufferString("")
 			f, err := format.FormatterFor(buf, format.CSVFormat, false)
 			assert.NoError(t, err)
-			f.Format(true, tc.i)
+			err = f.Format(true, "", tc.i)
+			if tc.s == "" {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 			assert.Equal(t, tc.s, buf.String())
 		})
 	}
@@ -136,7 +155,8 @@ func TestNewFormatter(t *testing.T) {
 			buf := bytes.NewBufferString("")
 			f, err := format.FormatterFor(buf, format.CSVFormat, false)
 			assert.NoError(t, err)
-			f.Format(true, tc.i)
+			err = f.Format(true, "", tc.i)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.s, buf.String())
 		})
 	}

--- a/format/json.go
+++ b/format/json.go
@@ -13,10 +13,10 @@ func NewJSONFormatter(out io.Writer, header bool) *JSON {
 	return &JSON{out}
 }
 
-func (j JSON) Format(wide bool, i interface{}) error {
+func (j JSON) Format(wide bool, selector string, i interface{}) error {
 	return json.NewEncoder(j.out).Encode(i)
 }
 
-func (j JSON) FormatList(wide bool, items []interface{}) error {
+func (j JSON) FormatList(wide bool, selector string, items []interface{}) error {
 	return json.NewEncoder(j.out).Encode(items)
 }

--- a/format/organization.go
+++ b/format/organization.go
@@ -2,41 +2,9 @@ package format
 
 import "github.com/rockset/rockset-go-client/openapi"
 
-var OrgFormatter = StructFormatter{
-	[]Header{
-		{
-			DisplayName: "DisplayName",
-			FieldName:   "DisplayName",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "ID",
-			FieldName:   "Id",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "User",
-			FieldName:   "RocksetUser",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "External ID",
-			FieldName:   "ExternalId",
-			FieldFn:     getFieldByName,
-			Wide:        true,
-		},
-		{
-			DisplayName: "Created At",
-			FieldName:   "CreatedAt",
-			FieldFn:     getFieldByName,
-			Wide:        true,
-		},
-		// []openapi.Cluster
-		//{
-		//	FieldName: "Clusters",
-		//	FieldFn:   getArrayFieldByName,
-		//},
-	},
+var OrganizationDefaultSelector = DefaultSelector{
+	Normal: "Display Name:.display_name,ID:.id,User:.rockset_user",
+	Wide:   "Display Name:.display_name,ID:.id,User:.rockset_user,External ID:.external_id,Created At:.created_at",
 }
 
 // just to list available fields

--- a/format/query.go
+++ b/format/query.go
@@ -2,40 +2,9 @@ package format
 
 import "github.com/rockset/rockset-go-client/openapi"
 
-var QueryInfoFormatter = StructFormatter{
-	[]Header{
-		{
-			DisplayName: "Query ID",
-			FieldName:   "QueryId",
-			FieldFn:     getFieldByName,
-		},
-		{
-			FieldName: "Status",
-			FieldFn:   getFieldByName,
-		},
-		{
-			DisplayName: "Executed By",
-			FieldName:   "ExecutedBy",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Submitted At",
-			FieldName:   "SubmittedAt",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Expires At",
-			FieldName:   "ExpiresAt",
-			FieldFn:     getFieldByName,
-			Wide:        true,
-		},
-		{
-			DisplayName: "SQL",
-			FieldName:   "Sql",
-			FieldFn:     getFieldByName,
-			Wide:        true,
-		},
-	},
+var QueryDefaultSelector = DefaultSelector{
+	Normal: "Query ID:.query_id,Status:.status,Executed By:.executed_by,Submitted At:.submitted_at",
+	Wide:   "Query ID:.query_id,Status:.status,Executed By:.executed_by,Submitted At:.submitted_at,Expires At:.expires_at,SQL:.sql",
 }
 
 var _ = openapi.QueryInfo{

--- a/format/query_lambda.go
+++ b/format/query_lambda.go
@@ -2,47 +2,9 @@ package format
 
 import "github.com/rockset/rockset-go-client/openapi"
 
-var QueryLambdaFormatter = StructFormatter{
-	[]Header{
-		{
-			FieldName: "Workspace",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "Name",
-			FieldFn:   getFieldByName,
-		},
-		{
-			DisplayName: "Last Updated By",
-			FieldName:   "LastUpdatedBy",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Last Updated",
-			FieldName:   "LastUpdated",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Latest Version",
-			FieldName:   "LatestVersion",
-			FieldFn:     getStructFieldByName("Version"),
-		},
-		{
-			DisplayName: "Description",
-			FieldName:   "LatestVersion",
-			FieldFn:     getStructFieldByName("Description"),
-			Wide:        true,
-		},
-		{
-			DisplayName: "Version Count",
-			FieldName:   "VersionCount",
-			FieldFn:     getFieldByName,
-		},
-		{
-			FieldName: "Collections",
-			FieldFn:   getArrayFieldByName,
-		},
-	},
+var QueryLambdaDefaultSelector = DefaultSelector{
+	Normal: "Workspace:.workspace,Name:.name,Last Updated By:.last_updated_by,Last Updated:.last_updated,Latest Version:.latest_version.version,Version Count:.version_count,Collections:.collections",
+	Wide:   "Workspace:.workspace,Name:.name,Last Updated By:.last_updated_by,Last Updated:.last_updated,Latest Version:.latest_version.version,Description:.latest_version.description,Version Count:.version_count,Collections:.collections",
 }
 
 var _ = openapi.QueryLambda{
@@ -76,25 +38,9 @@ var _ = openapi.QueryLambda{
 	Workspace:    nil,
 }
 
-var QueryLambdaTagFormatter = StructFormatter{
-	[]Header{
-		{
-			FieldName:   "TagName",
-			DisplayName: "Tag",
-			FieldFn:     getFieldByName,
-		},
-		{
-			FieldName:   "Version",
-			DisplayName: "Description",
-			FieldFn:     getStructFieldByName("Description"),
-			Wide:        true,
-		},
-		{
-			FieldName:   "Version",
-			DisplayName: "State",
-			FieldFn:     getStructFieldByName("State"),
-		},
-	},
+var QueryLambdaTagDefaultSelector = DefaultSelector{
+	Normal: "Tag:.tag_name,State:.version.state",
+	Wide:   "Tag:.tag_name,Description:.version.description,State:.version.state",
 }
 
 var _ = openapi.QueryLambdaTag{

--- a/format/selection_string.go
+++ b/format/selection_string.go
@@ -1,0 +1,156 @@
+package format
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type PathElem struct {
+	FieldName string
+
+	HasArraySelector bool
+	ArrayIndex       int
+}
+
+type SelectionString struct {
+	Path       []PathElem
+	ColumnName string
+}
+
+type Selector []SelectionString
+
+func ParseSelectionString(s string) (Selector, error) {
+	elems := strings.Split(s, ",")
+	columns := make([]SelectionString, 0)
+
+	for _, elem := range elems {
+		segments := strings.Split(elem, ":")
+		columnName := segments[0]
+		pathString := segments[0]
+		if len(segments) == 2 {
+			pathString = segments[1]
+		}
+
+		path := strings.Split(pathString, ".")[1:]
+		if pathString == "." {
+			path = make([]string, 0)
+		}
+
+		richPath := make([]PathElem, 0)
+		for _, v := range path {
+			pathSplit := strings.Split(v, "[")
+			field := pathSplit[0]
+			if len(pathSplit) == 2 {
+				res, err := strconv.ParseInt(strings.Trim(pathSplit[1], "[] "), 10, 64)
+				if err != nil {
+					return make([]SelectionString, 0), err
+				}
+				richPath = append(richPath, PathElem{
+					FieldName:        field,
+					HasArraySelector: true,
+					ArrayIndex:       int(res),
+				})
+			} else {
+				richPath = append(richPath, PathElem{
+					FieldName:        field,
+					HasArraySelector: false,
+					ArrayIndex:       0,
+				})
+			}
+		}
+
+		columns = append(columns, SelectionString{
+			Path:       richPath,
+			ColumnName: columnName,
+		})
+	}
+
+	return columns, nil
+}
+
+func (r Selector) Headers() []string {
+	headers := make([]string, len(r))
+	for i, sel := range r {
+		headers[i] = sel.ColumnName
+	}
+	return headers
+}
+
+func (r Selector) Fields(data any) ([]string, error) {
+	fields := make([]string, len(r))
+	for i, sel := range r {
+		value, err := sel.Select(data)
+		if err != nil {
+			return nil, err
+		}
+		valueAsString, err := AnyAsString(value)
+		if err != nil {
+			return nil, err
+		}
+		fields[i] = valueAsString
+	}
+	return fields, nil
+}
+
+func findFieldByJsonTag(value reflect.Value, jsonTag string) (reflect.Value, error) {
+	for i := 0; i < value.Type().NumField(); i++ {
+		tag := value.Type().Field(i).Tag.Get("json")
+		jsonName := strings.Split(tag, ",")[0]
+		if jsonName == jsonTag {
+			return value.FieldByName(value.Type().Field(i).Name), nil
+		}
+	}
+	return reflect.Value{}, fmt.Errorf("could not find json tag %s in type %s", jsonTag, value.Type().Name())
+}
+
+func (r SelectionString) Select(obj any) (any, error) {
+	cur := reflect.Indirect(reflect.ValueOf(obj))
+	curPath := r.Path
+
+	for len(curPath) > 0 {
+		next, rest := curPath[0], curPath[1:]
+
+		if !cur.IsValid() {
+			return nil, fmt.Errorf("selector %s is not valid on type %s", r.ToString(), reflect.TypeOf(obj).Name())
+		} else if cur.Kind() == reflect.Ptr && cur.IsNil() {
+			return nil, nil
+		} else if cur.IsZero() {
+			return nil, nil
+		}
+
+		var err error
+		cur, err = findFieldByJsonTag(reflect.Indirect(cur), next.FieldName)
+		if err != nil {
+			return nil, fmt.Errorf("selector %s is not valid on type %s: %s", r.ToString(), reflect.TypeOf(obj).Name(), err.Error())
+		}
+
+		if next.HasArraySelector {
+			cur = cur.Index(next.ArrayIndex)
+		}
+
+		curPath = rest
+	}
+
+	if !cur.IsValid() {
+		return nil, fmt.Errorf("selector %s is not valid on type %s", r.ToString(), reflect.TypeOf(obj).Name())
+	}
+
+	return cur.Interface(), nil
+}
+
+func (r SelectionString) ToString() string {
+	path := make([]string, 0)
+	for _, elem := range r.Path {
+		path = append(path, elem.ToString())
+	}
+	return "." + strings.Join(path, ".")
+}
+
+func (r PathElem) ToString() string {
+	if r.HasArraySelector {
+		return fmt.Sprintf("%s[%d]", r.FieldName, r.ArrayIndex)
+	}
+	return r.FieldName
+}

--- a/format/user.go
+++ b/format/user.go
@@ -1,34 +1,6 @@
 package format
 
-var UserFormatter = StructFormatter{
-	[]Header{
-		{
-			FieldName:   "FirstName",
-			DisplayName: "First Name",
-			FieldFn:     getFieldByName,
-		},
-		{
-			FieldName:   "LastName",
-			DisplayName: "Last Name",
-			FieldFn:     getFieldByName,
-		},
-		{
-			FieldName: "Email",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "State",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName:   "CreatedAt",
-			DisplayName: "Created At",
-			FieldFn:     getFieldByName,
-		},
-		{
-			FieldName: "Roles",
-			Wide:      true,
-			FieldFn:   getArrayFieldByName,
-		},
-	},
+var UserDefaultSelector = DefaultSelector{
+	Normal: "First Name:.first_name,Last Name:.last_name,Email:.email,State:.state,Created At:.created_at",
+	Wide:   "First Name:.first_name,Last Name:.last_name,Email:.email,State:.state,Created At:.created_at,Roles:.roles",
 }

--- a/format/view.go
+++ b/format/view.go
@@ -2,42 +2,9 @@ package format
 
 import "github.com/rockset/rockset-go-client/openapi"
 
-var ViewFormatter = StructFormatter{
-	[]Header{
-		{
-			FieldName: "Workspace",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "Name",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "Description",
-			FieldFn:   getFieldByName,
-			Wide:      true,
-		},
-		{
-			DisplayName: "Created By",
-			FieldName:   "CreatorEmail",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Created At",
-			FieldName:   "CreatedAt",
-			FieldFn:     getFieldByName,
-			Wide:        true,
-		},
-		{
-			FieldName: "State",
-			FieldFn:   getFieldByName,
-		},
-		{
-			DisplayName: "SQL",
-			FieldName:   "QuerySql",
-			FieldFn:     getFieldByName,
-		},
-	},
+var ViewDefaultSelector = DefaultSelector{
+	Normal: "Workspace:.workspace,Name:.name,Created By:.creator_email,State:.state,SQL:.query_sql",
+	Wide:   "Workspace:.workspace,Name:.name,Description:.description,Created By:.creator_email,Created At:.created_at,State:.state,SQL:.query_sql",
 }
 
 // just to list available fields

--- a/format/virtual_instance.go
+++ b/format/virtual_instance.go
@@ -1,39 +1,6 @@
 package format
 
-var VirtualInstanceFormatter = StructFormatter{
-	[]Header{
-		{
-			FieldName: "Name",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "Id",
-			FieldFn:   getFieldByName,
-			Wide:      true,
-		},
-		{
-			FieldName: "Description",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "State",
-			FieldFn:   getFieldByName,
-		},
-		{
-			DisplayName: "Default VI",
-			FieldName:   "DefaultVi",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Current Size",
-			FieldName:   "CurrentSize",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Desired Size",
-			FieldName:   "DesiredSize",
-			FieldFn:     getFieldByName,
-			Wide:        true,
-		},
-	},
+var VirtualInstanceDefaultSelector = DefaultSelector{
+	Normal: "Name:.name,Description:.description,State:.state,Default VI:.default_vi,Current Size:.current_size",
+	Wide:   "Name:.name,ID:.id,description:.description,State:.state,Default VI:.default_vi,Current Size:.current_size,Desired Size:.desired_size",
 }

--- a/format/workspace.go
+++ b/format/workspace.go
@@ -2,34 +2,9 @@ package format
 
 import "github.com/rockset/rockset-go-client/openapi"
 
-var WorkspaceFormatter = StructFormatter{
-	[]Header{
-		{
-			FieldName: "Name",
-			FieldFn:   getFieldByName,
-		},
-		{
-			FieldName: "Description",
-			FieldFn:   getFieldByName,
-			Wide:      true,
-		},
-		{
-			DisplayName: "Collections",
-			FieldName:   "CollectionCount",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Created By",
-			FieldName:   "CreatedBy",
-			FieldFn:     getFieldByName,
-		},
-		{
-			DisplayName: "Created At",
-			FieldName:   "CreatedAt",
-			FieldFn:     getFieldByName,
-			Wide:        true,
-		},
-	},
+var WorkspaceDefaultSelector = DefaultSelector{
+	Normal: "Name:.name,Collections:.collection_count,Created By:.created_by",
+	Wide:   "Name:.name,Description:.description,Collections:.collection_count,Created By:.created_by,Created At:.created_at",
 }
 
 // just to list available fields


### PR DESCRIPTION
Implements `--selector`, allowing the user to select their own columns for CSV and table output. Uses reflection to traverse structs, and returns errors if a bad selector is given.

TODO: What would be a good way to reveal what selectors are valid? (How deep should we go? Do we have any recursive structures?)