### PR TITLE
[DEV-169] Update CLI selection so users can quickly see what selectors are available, and add richer errors [2/2]

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -1,6 +1,7 @@
 package format
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
@@ -126,6 +127,14 @@ func valueAsString(value reflect.Value) (string, error) {
 			return "", nil
 		}
 		return valueAsString(reflect.Indirect(value))
+	case reflect.Struct:
+		out, err := json.Marshal(value.Interface())
+		if err != nil {
+			return "", err
+		}
+		return string(out), nil
+	case reflect.Invalid:
+		return "NULL", nil
 	default:
 		return "", fmt.Errorf("unhandled kind %s", k)
 	}

--- a/format/selection_string.go
+++ b/format/selection_string.go
@@ -34,6 +34,10 @@ func ParseSelectionString(s string) (Selector, error) {
 		}
 
 		path := strings.Split(pathString, ".")[1:]
+		if len(path) == 0 {
+			continue
+		}
+
 		if pathString == "." {
 			path = make([]string, 0)
 		}
@@ -67,6 +71,10 @@ func ParseSelectionString(s string) (Selector, error) {
 		})
 	}
 
+	if len(columns) == 0 {
+		return columns, fmt.Errorf("selector '%s' invalid; double-check to ensure that your selectors begin with a period", s)
+	}
+
 	return columns, nil
 }
 
@@ -94,11 +102,18 @@ func (r Selector) Fields(data any) ([]string, error) {
 	return fields, nil
 }
 
+func getJsonTagOfField(field reflect.StructField) string {
+	tag := field.Tag.Get("json")
+	return strings.Split(tag, ",")[0]
+}
+
 func findFieldByJsonTag(value reflect.Value, jsonTag string) (reflect.Value, error) {
+	if value.Kind() != reflect.Struct {
+		return reflect.Value{}, fmt.Errorf("invalid selector, type %s is not a struct", value.Type())
+	}
 	for i := 0; i < value.Type().NumField(); i++ {
-		tag := value.Type().Field(i).Tag.Get("json")
-		jsonName := strings.Split(tag, ",")[0]
-		if jsonName == jsonTag {
+		tag := getJsonTagOfField(value.Type().Field(i))
+		if tag == jsonTag {
 			return value.FieldByName(value.Type().Field(i).Name), nil
 		}
 	}
@@ -109,11 +124,26 @@ func (r SelectionString) Select(obj any) (any, error) {
 	cur := reflect.Indirect(reflect.ValueOf(obj))
 	curPath := r.Path
 
+	makeError := func(err error) error {
+		typeName := reflect.TypeOf(obj).Name()
+		possibleSelectors := GetPossibleSelectorsFor(obj)
+		selector := r.ToString()
+
+		prefix := fmt.Sprintf("selector %s is not valid on type %s", selector, typeName)
+		suffix := fmt.Sprintf("possible selectors on type %s include: %s", typeName, strings.Join(possibleSelectors, "; "))
+		if err == nil {
+			return fmt.Errorf("%s - %s", prefix, suffix)
+		} else {
+			return fmt.Errorf("%s: %s - %s", prefix, err.Error(), suffix)
+		}
+
+	}
+
 	for len(curPath) > 0 {
 		next, rest := curPath[0], curPath[1:]
 
 		if !cur.IsValid() {
-			return nil, fmt.Errorf("selector %s is not valid on type %s", r.ToString(), reflect.TypeOf(obj).Name())
+			return nil, makeError(nil)
 		} else if cur.Kind() == reflect.Ptr && cur.IsNil() {
 			return nil, nil
 		} else if cur.IsZero() {
@@ -123,10 +153,13 @@ func (r SelectionString) Select(obj any) (any, error) {
 		var err error
 		cur, err = findFieldByJsonTag(reflect.Indirect(cur), next.FieldName)
 		if err != nil {
-			return nil, fmt.Errorf("selector %s is not valid on type %s: %s", r.ToString(), reflect.TypeOf(obj).Name(), err.Error())
+			return nil, makeError(err)
 		}
 
 		if next.HasArraySelector {
+			if next.ArrayIndex < 0 || next.ArrayIndex >= cur.Len() {
+				return nil, nil
+			}
 			cur = cur.Index(next.ArrayIndex)
 		}
 
@@ -134,7 +167,7 @@ func (r SelectionString) Select(obj any) (any, error) {
 	}
 
 	if !cur.IsValid() {
-		return nil, fmt.Errorf("selector %s is not valid on type %s", r.ToString(), reflect.TypeOf(obj).Name())
+		return nil, makeError(nil)
 	}
 
 	return cur.Interface(), nil
@@ -153,4 +186,49 @@ func (r PathElem) ToString() string {
 		return fmt.Sprintf("%s[%d]", r.FieldName, r.ArrayIndex)
 	}
 	return r.FieldName
+}
+
+func GetPossibleSelectorsFor(data any) []string {
+	type SelectorQueueObject struct {
+		typ    reflect.Type
+		prefix string
+	}
+
+	selectors := make([]string, 1)
+	selectors[0] = "."
+	queue := make([]SelectorQueueObject, 1)
+	queue[0] = SelectorQueueObject{
+		typ:    reflect.TypeOf(data),
+		prefix: "",
+	}
+
+	for len(queue) > 0 {
+		cur, rest := queue[0], queue[1:]
+		queue = rest
+
+		for i := 0; i < cur.typ.NumField(); i++ {
+			field := cur.typ.Field(i)
+			tag := getJsonTagOfField(field)
+			if tag == "" {
+				continue
+			}
+			myPrefix := cur.prefix + "." + tag
+			selectors = append(selectors, myPrefix)
+
+			if field.Type.Kind() == reflect.Struct {
+				queue = append(queue, SelectorQueueObject{
+					typ:    field.Type,
+					prefix: myPrefix,
+				})
+			}
+			if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct {
+				queue = append(queue, SelectorQueueObject{
+					typ:    field.Type.Elem(),
+					prefix: myPrefix,
+				})
+			}
+		}
+
+	}
+	return selectors
 }


### PR DESCRIPTION
Also has that array index out of bounds errors and other cases where we get a `nil` or invalid type are treated and printed as `NULL`, and that struct selections are printed as json.

Examples:

Selects nonexistent field –
```
❯ ./cli list lambda --selector=.afsguyuas
Error: selector .afsguyuas is not valid on type QueryLambda: could not find json tag afsguyuas in type QueryLambda - possible selectors on type QueryLambda include: .; .collections; .last_updated; .last_updated_by; .latest_version; .name; .version_count; .workspace; .latest_version.collections; .latest_version.created_at; .latest_version.created_by; .latest_version.created_by_apikey_name; .latest_version.description; .latest_version.name; .latest_version.public_access_id; .latest_version.sql; .latest_version.state; .latest_version.stats; .latest_version.version; .latest_version.workspace; .latest_version.sql.default_parameters; .latest_version.sql.query; .latest_version.stats.last_executed; .latest_version.stats.last_executed_by; .latest_version.stats.last_execution_error; .latest_version.stats.last_execution_error_message
Usage:
  rockset list lambda [flags]

Aliases:
  lambda, ql

Flags:
  -h, --help               help for lambda
  -W, --workspace string   only show query lambdas for the selected workspace (default "all")

Global Flags:
      --cluster string    override Rockset cluster
      --config string     config file (default is $HOME/.rockset.yaml)
      --context string    override currently selected configuration context
      --debug             enable debug output
      --format string     output format (csv, json, table) (default "table")
      --header            show header (default true)
      --selector string   Allows displaying custom values in tables (ignored if --format is anything other than "table" or "csv"). Has the format "Column Name:.Field1.Subfield,Column 2 Name:.Selector" etc. The column name and colon can be ommitted, in which case the column and selector will be identical.
      --wide              show extended fields


ERROR: selector .afsguyuas is not valid on type QueryLambda: could not find json tag afsguyuas in type QueryLambda - possible selectors on type QueryLambda include: .; .collections; .last_updated; .last_updated_by; .latest_version; .name; .version_count; .workspace; .latest_version.collections; .latest_version.created_at; .latest_version.created_by; .latest_version.created_by_apikey_name; .latest_version.description; .latest_version.name; .latest_version.public_access_id; .latest_version.sql; .latest_version.state; .latest_version.stats; .latest_version.version; .latest_version.workspace; .latest_version.sql.default_parameters; .latest_version.sql.query; .latest_version.stats.last_executed; .latest_version.stats.last_executed_by; .latest_version.stats.last_execution_error; .latest_version.stats.last_execution_error_message
```

Malformed selector–
```
❯ ./cli list lambda --selector=name
Error: selector 'name' invalid; double-check to ensure that your selectors begin with a period
Usage:
  rockset list lambda [flags]

Aliases:
  lambda, ql

Flags:
  -h, --help               help for lambda
  -W, --workspace string   only show query lambdas for the selected workspace (default "all")

Global Flags:
      --cluster string    override Rockset cluster
      --config string     config file (default is $HOME/.rockset.yaml)
      --context string    override currently selected configuration context
      --debug             enable debug output
      --format string     output format (csv, json, table) (default "table")
      --header            show header (default true)
      --selector string   Allows displaying custom values in tables (ignored if --format is anything other than "table" or "csv"). Has the format "Column Name:.Field1.Subfield,Column 2 Name:.Selector" etc. The column name and colon can be ommitted, in which case the column and selector will be identical.
      --wide              show extended fields


ERROR: selector 'name' invalid; double-check to ensure that your selectors begin with a period
```

Tries to go in on a string or other non-struct field
```
❯ ./cli list workspace --selector='.name.abc'
Error: selector .name.abc is not valid on type Workspace: invalid selector, type string is not a struct - possible selectors on type Workspace include: .; .collection_count; .created_at; .created_by; .description; .name
Usage:
  rockset list workspaces [flags]

Aliases:
  workspaces, workspace, ws

Flags:
  -h, --help   help for workspaces

Global Flags:
      --cluster string    override Rockset cluster
      --config string     config file (default is $HOME/.rockset.yaml)
      --context string    override currently selected configuration context
      --debug             enable debug output
      --format string     output format (csv, json, table) (default "table")
      --header            show header (default true)
      --selector string   Allows displaying custom values in tables (ignored if --format is anything other than "table" or "csv"). Has the format "Column Name:.Field1.Subfield,Column 2 Name:.Selector" etc. The column name and colon can be ommitted, in which case the column and selector will be identical.
      --wide              show extended fields


ERROR: selector .name.abc is not valid on type Workspace: invalid selector, type string is not a struct - possible selectors on type Workspace include: .; .collection_count; .created_at; .created_by; .description; .name
```

Null values–
```
❯ ./cli list lambda --selector='.collections[0]'
+--------------------------------------------+
|               COLLECTIONS[0]               |
+--------------------------------------------+
| rockstore.IngestLogV2                      |
| rockstore.CpuUsageLog                      |
| rockstore.MetricLog                        |
| rockstore.SchedulerEventLog                |
| rockstore.CpuUsageLog                      |
| commons._events                            |
| commons._events                            |
| rockstore.QueryLog                         |
| rockstore.QueryLog                         |
| rockstore.QueryLog                         |
| NULL                                       |
| NULL                                       |
| NULL                                       |
| rockstore.QueryLogV2                       |
| rockstore.IngestLogV2                      |
| rockstore.VirtualInstanceMetricsLog        |
| NULL                                       |
| rockstore.EventLog                         |
| rockstore.IngestLogV2                      |
| rockstore.EventLog                         |
| rockstore.EventLog                         |
| commons.t00007f21e5480440                  |
| commons.t00007f179c04e540                  |
| rockstore.EventLog                         |
| rockstore.EventLog                         |
| rockstore.QueryLogV2                       |
| rockstore.BillingComputeLog                |
| rockstore.BillingIngestUsage               |
| rockstore.BillingEventLog                  |
| rockstore.BillingEventLog                  |
| rockstore.BillingStorageLog                |
| rockstore.BillingEventLog                  |
| rockstore.BillingEventLog                  |
| rockstore.CpuUsageLog                      |
| rockstore.CpuUsageLogV2                    |
| rockstore.IngestLogKinesis                 |
| NULL                                       |
| NULL                                       |
| rockstore.VirtualInstanceMetricsLog        |
| rockstore.QueryLogV2                       |
| rockstore.QueryLogV2                       |
| rockstore.QueryLogV2                       |
| rockstore.IngestLogV2                      |
| NULL                                       |
| NULL                                       |
| NULL                                       |
| NULL                                       |
| NULL                                       |
| NULL                                       |
| rockstore.StorageLogV2                     |
| NULL                                       |
| rockstore.BrianTestCpuUsageLog             |
| rockstore.EventLogKinesis                  |
| rockstore.ViMetricsCpuRollup               |
| rockstore.EventLogKinesis                  |
| rockstore.VirtualInstanceMetricsLogKinesis |
| NULL                                       |
| rockstore.IngestLogKinesis                 |
| NULL                                       |
| NULL                                       |
| commons.sandbox-richard-cpuusage           |
| commons._events                            |
+--------------------------------------------+
```

Struct values–
```
❯ ./cli list workspace --selector='.'
+---------------------------------------------------------------------------------------------------------------------------------------+
|                                                                   .                                                                   |
+---------------------------------------------------------------------------------------------------------------------------------------+
| {"collection_count":6,"created_at":"2023-01-24T18:58:33Z","created_by":"pme@rockset.com","description":"Collections                   |
| used to power the metrics in the Rockset console","name":"console"}                                                                   |
| {"collection_count":2,"created_at":"2022-12-09T22:23:00Z","created_by":"scott@rockset.com","name":"slos"}                             |
| {"collection_count":0,"created_at":"2023-09-08T04:30:06Z","created_by":"morgana@rockset.com","description":"sdfas","name":"deleteme"} |
| {"collection_count":18,"created_at":"2019-05-02T02:15:56Z","description":"","name":"rockstore"}                                       |
| {"collection_count":34,"description":"default                                                                                         |
| workspace","name":"commons"}                                                                                                          |
| {"collection_count":1,"created_at":"2022-09-07T00:45:24Z","created_by":"pme@rockset.com","description":"created                       |
| by Rockset terraform provider","name":"sla"}                                                                                          |
| {"collection_count":2,"created_at":"2022-11-23T21:49:51Z","created_by":"julius@rockset.com","description":"","name":"test"}           |
+---------------------------------------------------------------------------------------------------------------------------------------+
```