### PR TITLE
[DEV-170] Flip csv/tables for single-entity requests

### DIFF
--- a/format/csv.go
+++ b/format/csv.go
@@ -34,18 +34,25 @@ func (c CSV) Format(wide bool, selector string, i interface{}) error {
 	defer c.w.Flush()
 
 	if c.Header {
-		err := c.w.Write(selection.Headers())
+		c.w.Write([]string{"key", "value"})
 		if err != nil {
 			return fmt.Errorf("failed to write csv: %w", err)
 		}
 	}
-	fields, err := selection.Fields(i)
-	if err != nil {
-		return fmt.Errorf("failed to write csv: %w", err)
-	}
-	err = c.w.Write(fields)
-	if err != nil {
-		return fmt.Errorf("failed to write csv: %w", err)
+
+	for _, sel := range selection {
+		value, err := sel.Select(i)
+		if err != nil {
+			return fmt.Errorf("failed to write csv: %w", err)
+		}
+		valueAsString, err := AnyAsString(value)
+		if err != nil {
+			return fmt.Errorf("failed to write csv: %w", err)
+		}
+		err = c.w.Write([]string{sel.ColumnName, valueAsString})
+		if err != nil {
+			return fmt.Errorf("failed to write csv: %w", err)
+		}
 	}
 	return nil
 }

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -121,7 +121,7 @@ func TestFormatter(t *testing.T) {
 			buf := bytes.NewBufferString("")
 			f, err := format.FormatterFor(buf, format.CSVFormat, false)
 			assert.NoError(t, err)
-			err = f.Format(true, "", tc.i)
+			err = f.FormatList(true, "", []any{tc.i})
 			if tc.s == "" {
 				assert.Error(t, err)
 			} else {
@@ -155,7 +155,7 @@ func TestNewFormatter(t *testing.T) {
 			buf := bytes.NewBufferString("")
 			f, err := format.FormatterFor(buf, format.CSVFormat, false)
 			assert.NoError(t, err)
-			err = f.Format(true, "", tc.i)
+			err = f.FormatList(true, "", []any{tc.i})
 			assert.NoError(t, err)
 			assert.Equal(t, tc.s, buf.String())
 		})

--- a/format/table.go
+++ b/format/table.go
@@ -31,15 +31,21 @@ func (t Table) Format(wide bool, selector string, i interface{}) error {
 	}
 
 	if t.Header {
-		t.w.SetHeader(selection.Headers())
+		t.w.SetHeader([]string{"key", "value"})
 	}
 
-	fields, err := selection.Fields(i)
-	if err != nil {
-		return err
+	for _, sel := range selection {
+		value, err := sel.Select(i)
+		if err != nil {
+			return err
+		}
+		valueAsString, err := AnyAsString(value)
+		if err != nil {
+			return err
+		}
+		t.w.Append([]string{sel.ColumnName, valueAsString})
 	}
 
-	t.w.Append(fields)
 	t.w.Render()
 
 	return nil


### PR DESCRIPTION
`get` calls now format this way:
```
❯ ./cli get workspace console
+-------------+--------------------------------+
|     KEY     |             VALUE              |
+-------------+--------------------------------+
| Name        | console                        |
| Description | Collections used to power the  |
|             | metrics in the Rockset console |
| Collections |                              6 |
| Created By  | pme@rockset.com                |
| Created At  | 2023-01-24T18:58:33Z           |
+-------------+--------------------------------+
```

Since they return single entities. (Same for CSV)