### PR TITLE
add sort function

### DIFF
--- a/cmd/collection.go
+++ b/cmd/collection.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/rockset/cli/format"
+	"github.com/rockset/cli/sort"
 	"github.com/spf13/cobra"
 	"os"
 	"strings"
@@ -123,6 +124,18 @@ func newListCollectionsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			ms := sort.Multi[openapi.Collection]{
+				LessFuncs: []func(p1 *openapi.Collection, p2 *openapi.Collection) bool{
+					func(c1 *openapi.Collection, c2 *openapi.Collection) bool {
+						return c1.GetWorkspace() < c2.GetWorkspace()
+					},
+					func(c1 *openapi.Collection, c2 *openapi.Collection) bool {
+						return c1.GetName() < c2.GetName()
+					},
+				},
+			}
+			ms.Sort(list)
 
 			return formatList(cmd, format.ToInterfaceArray(list))
 		},

--- a/sort/multi.go
+++ b/sort/multi.go
@@ -1,0 +1,43 @@
+package sort
+
+import "sort"
+
+// Multi is used to sort a slice of T using the list of LessFuncs, so you can order a table by different columns
+type Multi[T any] struct {
+	changes   []T
+	LessFuncs []func(p1, p2 *T) bool
+}
+
+func (ms *Multi[T]) Sort(changes []T) {
+	ms.changes = changes
+	sort.Sort(ms)
+}
+
+func (ms *Multi[T]) Len() int {
+	return len(ms.changes)
+}
+
+func (ms *Multi[T]) Swap(i, j int) {
+	ms.changes[i], ms.changes[j] = ms.changes[j], ms.changes[i]
+}
+
+func (ms *Multi[T]) Less(i, j int) bool {
+	p, q := &ms.changes[i], &ms.changes[j]
+	// Try all but the last comparison.
+	var k int
+	for k = 0; k < len(ms.LessFuncs)-1; k++ {
+		less := ms.LessFuncs[k]
+		switch {
+		case less(p, q):
+			// p < q, so we have a decision.
+			return true
+		case less(q, p):
+			// p > q, so we have a decision.
+			return false
+		}
+		// p == q; try the next comparison.
+	}
+	// All comparisons to here said "equal", so just return whatever
+	// the final comparison reports.
+	return ms.LessFuncs[k](p, q)
+}

--- a/sort/multi_test.go
+++ b/sort/multi_test.go
@@ -1,0 +1,40 @@
+package sort_test
+
+import (
+	"github.com/rockset/cli/sort"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type TestStruct struct {
+	X string
+	Y int
+}
+
+func TestSort(t *testing.T) {
+	list := []TestStruct{
+		{X: "a", Y: 2},
+		{X: "b", Y: 2},
+		{X: "b", Y: 1},
+		{X: "a", Y: 1},
+	}
+
+	m := sort.Multi[TestStruct]{LessFuncs: []func(*TestStruct, *TestStruct) bool{
+		func(testStruct *TestStruct, testStruct2 *TestStruct) bool {
+			return testStruct.X < testStruct2.X
+		},
+		func(testStruct *TestStruct, testStruct2 *TestStruct) bool {
+			return testStruct.Y < testStruct2.Y
+		},
+	}}
+	m.Sort(list)
+
+	assert.Equal(t, "a", list[0].X)
+	assert.Equal(t, 1, list[0].Y)
+	assert.Equal(t, "a", list[1].X)
+	assert.Equal(t, 2, list[1].Y)
+	assert.Equal(t, "b", list[2].X)
+	assert.Equal(t, 1, list[2].Y)
+	assert.Equal(t, "b", list[3].X)
+	assert.Equal(t, 2, list[3].Y)
+}


### PR DESCRIPTION
```
+-----------+------------------------------------+--------------------------------+-----------+----------+-------------+-----------+-----------------------------+----------------------+
| WORKSPACE |                NAME                |          DESCRIPTION           | RETENTION |  STATUS  | INSERT ONLY | READ ONLY |         CREATED BY          |      CREATED AT      |
+-----------+------------------------------------+--------------------------------+-----------+----------+-------------+-----------+-----------------------------+----------------------+
| commons   | _events                            |                                |           | RESUMING |             |           |                             | 2023-08-31T18:59:34Z |
| commons   | archive-compute-batched            |                                |           | READY    | false       | false     | jeff@rockset.com            | 2023-02-09T19:08:35Z |
| commons   | ari-test                           |                                |           | READY    | false       | false     | haneeshr@rockset.com        | 2023-09-27T22:55:46Z |
| commons   | ari_test                           |                                |           | READY    | false       | false     | ari@rockset.com             | 2023-04-14T17:16:45Z |
| commons   | basekafka                          |                                |           | READY    |             | false     | scott@rockset.com           | 2021-08-26T19:03:45Z |
| commons   | buildkite_exceptions               | Log exceptions from buildkite  |   5184000 | READY    |             | false     | anubhav@rockset.com         | 2022-01-27T23:59:42Z |
|           |                                    | steps                          |           |          |             |           |                             |                      |
| commons   | compute-batched                    |                                |           | READY    | false       | false     | jeff@rockset.com            | 2023-02-09T19:11:15Z |
| commons   | dasg                               |                                |           | READY    | false       | false     | haneeshr@rockset.com        | 2023-06-12T18:44:39Z |
| commons   | delete                             | kristie                        |           | READY    | false       | false     | kristie@rockset.com         | 2023-10-11T00:10:45Z |
| commons   | e                                  |                                |           | READY    | false       | false     | jing@rockset.com            | 2023-01-06T18:24:08Z |
| commons   | langchain_demo                     |                                |           | READY    | false       | false     | anubhav@rockset.com         | 2023-06-08T20:52:27Z |
| commons   | langchain_demo2                    | langchain_demo2                |           | READY    | false       | false     | anubhav@rockset.com         | 2023-06-13T14:58:18Z |
| commons   | mongoTest                          |                                |           | READY    | false       | false     | ari@rockset.com             | 2023-04-27T22:55:33Z |
| commons   | mongoTest2                         |                                |           | READY    | false       | false     | ari@rockset.com             | 2023-04-27T23:00:37Z |
| commons   | queryperf_cbo_telemetry            | Collection having CBO          |   5184000 | READY    | false       | false     | nithinvenkatesh@rockset.com | 2023-08-17T21:06:33Z |
|           |                                    | telemetry related data for     |           |          |             |           |                             |                      |
|           |                                    | queries run in the Queryperf   |           |          |             |           |                             |                      |
|           |                                    | benchmark.                     |           |          |             |           |                             |                      |
| commons   | queryperf_query_hashes             | Mapping from query name to     |           | READY    | false       | false     | nithinvenkatesh@rockset.com | 2023-09-26T22:31:08Z |
|           |                                    | query hash for the queries in  |           |          |             |           |                             |                      |
|           |                                    | Queryperf namespace            |           |          |             |           |                             |                      |
| commons   | sandbox-richard-cpuusage           |                                |   2592000 | READY    | false       | false     | richard@rockset.com         | 2023-02-04T23:31:05Z |
| commons   | staging_cbo_telemetry              | CBO telemetry data for staging |  10368000 | READY    | false       | false     | nithinvenkatesh@rockset.com | 2023-09-18T23:19:35Z |
| commons   | test                               |                                |           | READY    | false       | false     | julius@rockset.com          | 2023-02-03T01:38:15Z |
| commons   | test-metrics-visibility-bulkingest |                                |     86400 | READY    | false       | false     | jing@rockset.com            | 2023-04-27T23:40:37Z |
| commons   | test-metrics-visibility2           |                                |     86400 | READY    | false       | false     | jing@rockset.com            | 2023-04-27T23:34:01Z |
| commons   | test-query-logs                    |                                |           | READY    | false       | false     | julius@rockset.com          | 2023-05-22T04:25:46Z |
| commons   | test-upload                        |                                |           | READY    | false       | false     | jeff@rockset.com            | 2023-03-02T01:20:00Z |
| commons   | testWhere                          |                                |           | READY    | false       | false     | ari@rockset.com             | 2022-11-07T23:08:33Z |
| commons   | test_geo                           |                                |           | READY    | false       | false     | haneeshr@rockset.com        | 2023-01-16T18:37:45Z |
| commons   | tests                              |                                |           | READY    | false       | false     | haneeshr@rockset.com        | 2023-06-12T22:45:14Z |
| console   | EventLogV1                         | created by Rockset terraform   |   2592000 | READY    | false       | false     | brandon@rockset.com         | 2023-10-09T23:04:22Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| console   | IngestLogV1                        | created by Rockset terraform   |   2592000 | READY    | false       | false     | brandon@rockset.com         | 2023-10-09T23:04:22Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| console   | QueryLogV1                         | created by Rockset terraform   |   2592000 | READY    | false       | false     | brandon@rockset.com         | 2023-10-09T23:04:22Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| console   | ViQlQueryRollup1mV1                | created by Rockset terraform   |   2592000 | READY    | true        | false     | brandon@rockset.com         | 2023-10-09T23:09:22Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| console   | ViQlQueryRollup30mV1               | created by Rockset terraform   |   2592000 | READY    | true        | false     | brandon@rockset.com         | 2023-10-09T23:04:22Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| console   | ViQlQueryRollup5mV1                | created by Rockset terraform   |   2592000 | READY    | true        | false     | brandon@rockset.com         | 2023-10-09T23:04:22Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| console   | ViQueryRollup1mV1                  | created by Rockset terraform   |   2592000 | READY    | true        | false     | brandon@rockset.com         | 2023-10-09T23:04:22Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| console   | ViQueryRollup30mV1                 | created by Rockset terraform   |   2592000 | READY    | true        | false     | brandon@rockset.com         | 2023-10-09T23:04:21Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| console   | ViQueryRollup5mV1                  | created by Rockset terraform   |   2592000 | READY    | true        | false     | brandon@rockset.com         | 2023-10-09T23:04:22Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| console   | VirtualInstanceMetricsLogV1        | created by Rockset terraform   |   2592000 | READY    | false       | false     | brandon@rockset.com         | 2023-10-09T23:04:22Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| rockstore | BillingComputeLogV2                | created by Rockset terraform   |   2592000 | READY    | false       | false     | julius@rockset.com          | 2022-12-15T03:12:05Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| rockstore | BillingComputeLogV3                | created by Rockset terraform   |   2592000 | READY    | false       | false     | jjye@rockset.com            | 2023-10-13T20:17:37Z |
|           |                                    | provider                       |           |          |             |           |                             |                      |
| rockstore | BillingCpuUsageLogV2               |                                |   2592000 | READY    | false       | false     | jjye@rockset.com            | 2022-12-21T20:30:29Z |
| rockstore | BillingCpuUsageLogV3               |                                |   2592000 | READY    | false       | false     | jjye@rockset.com            | 2023-10-13T20:18:12Z |
| rockstore | BillingEventLogV1                  |                                |           | READY    | false       | false     | jjye@rockset.com            | 2022-12-27T18:35:15Z |
| rockstore | BillingEventLogV2                  |                                |           | READY    | false       | false     | jjye@rockset.com            | 2023-10-13T20:19:18Z |
| rockstore | BillingStorageLogV2                |                                |           | READY    | false       | false     | jjye@rockset.com            | 2022-12-28T17:38:07Z |
| rockstore | BillingStorageLogV3                |                                |   2592000 | READY    | false       | false     | jjye@rockset.com            | 2023-10-13T20:18:44Z |
| rockstore | TaskEventLogV2                     |                                |   2592000 | READY    | false       | false     | jeff@rockset.com            | 2023-08-31T18:05:41Z |
| rockstore | ViMetricsCpuRollup                 |                                |   2592000 | READY    | true        | false     | scott@rockset.com           | 2022-10-20T22:21:15Z |
| rockstore | ViMetricsCpuRollupJiaJie           |                                |    604800 | READY    | true        | false     | jjye@rockset.com            | 2023-05-24T18:11:57Z |
| sla       | alb                                | ALB logs rolled up to one      |           | READY    | true        | false     | jeff@rockset.com            | 2023-08-31T18:07:19Z |
|           |                                    | minute intervals               |           |          |             |           |                             |                      |
| slos      | cron_liveness                      |                                |           | READY    | false       | false     | scott@rockset.com           | 2022-12-09T22:27:15Z |
| slos      | raw_slos_2                         |                                |  31536000 | READY    | false       | false     | haneeshr@rockset.com        | 2023-01-11T01:53:46Z |
+-----------+------------------------------------+--------------------------------+-----------+----------+-------------+-----------+-----------------------------+----------------------+
```
