### PR TITLE
[AC-225] Add array-mapping for selectors

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -125,7 +125,12 @@ func valueAsString(value reflect.Value, ff FieldFormatter) (string, error) {
 		a := make([]string, value.Len())
 		for i := 0; i < value.Len(); i++ {
 			x := value.Index(i)
-			a[i] = fmt.Sprintf("%v", x)
+			parsed, err := valueAsString(x, ff)
+			if err != nil {
+				a[i] = fmt.Sprintf("%v", x)
+			} else {
+				a[i] = parsed
+			}
 		}
 
 		return strings.Join(a, ", "), nil

--- a/format/integration.go
+++ b/format/integration.go
@@ -5,7 +5,15 @@ import "github.com/rockset/rockset-go-client/openapi"
 var IntegrationDefaultSelector = DefaultSelector{
 	Normal: []FieldSelection{
 		NewFieldSelection("Name", "name"),
-		// TODO need a selector for collections
+		{
+			ColumnName: "Collections",
+			Path: []PathElem{{
+				FieldName:       "collections",
+				HasArrayMapping: true,
+			}, {
+				FieldName: "name",
+			}},
+		},
 		// TODO need a selector which shows the type
 	},
 	Wide: []FieldSelection{

--- a/format/selection_test.go
+++ b/format/selection_test.go
@@ -1,6 +1,7 @@
 package format_test
 
 import (
+	"github.com/rockset/rockset-go-client/openapi"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,8 @@ func TestParseSelectionString(t *testing.T) {
 	tests := []string{
 		"Foo:.foo:size",
 		"Foo:.foo,Baz:.bar.baz:size",
+		"Arr:.foo.arr[1]",
+		"ArrMap:.foo.arr[].value",
 	}
 
 	for _, tst := range tests {
@@ -21,4 +24,42 @@ func TestParseSelectionString(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, tst, s.String())
 	}
+}
+
+func TestBasicSelection(t *testing.T) {
+	hello := "hello"
+	collection := openapi.Collection{Name: &hello}
+
+	s, err := format.ParseSelectionString(".name")
+	require.NoError(t, err)
+
+	name, err := s[0].Select(collection)
+	require.NoError(t, err)
+
+	assert.Equal(t, hello, name)
+}
+
+func TestSelectArrayMapping(t *testing.T) {
+	hello := "hello"
+	world := "world"
+
+	integration := openapi.Integration{
+		Collections: []openapi.Collection{{Name: &hello}, {Name: &world}},
+	}
+
+	s, err := format.ParseSelectionString(".collections[].name")
+	require.NoError(t, err)
+
+	arr, err := s[0].Select(integration)
+
+	switch typedArr := arr.(type) {
+	case []any:
+		assert.Equal(t, 2, len(typedArr))
+		assert.Equal(t, "hello", typedArr[0])
+		assert.Equal(t, "world", typedArr[1])
+		break
+	default:
+		assert.Fail(t, "returned non-array type")
+	}
+
 }


### PR DESCRIPTION
Allows selectors of the format `.arrayfield[].subfield` which applies the mapping following `[]` to all the elements of the array identified by the mapping preceding it. For example, selecting `.collections[].name` on `{collections: [{name: "a"}, {name: "b"}]}` would return `["a", "b"]`.

Also uses it to provide an additional default selector for integrations